### PR TITLE
Tiny fix to README example

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -111,7 +111,7 @@ Incrementally decoding the BioC XML file:
     import bioc
 
     # read from a file
-    with bioc.BioCXMLDocumentReader(filename, 'r') as reader:
+    with bioc.BioCXMLDocumentReader(filename) as reader:
         collection_info = reader.get_collection_info()
         for document in reader:
             # process document


### PR DESCRIPTION
Hey, I just noticed a small mistake in the README for using the BioCXMLDocumentReader(filename) and thought I might as well submit a pull request.